### PR TITLE
Add basic ticker management CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # demo_test_mme
+
+This repository contains sample code for managing ticker codes as referenced in the SRS document.
+
+## Usage
+
+Install requirements (none outside Python standard library) and run the CLI to update a ticker code:
+
+```bash
+python src/ticker.py <company_id> <new_ticker>
+```
+
+Example:
+
+```bash
+python src/ticker.py 1 NEWT
+```
+
+This will update the ticker for company ID `1` in `data/companies.csv`.
+
+## Running Tests
+
+```bash
+python -m unittest discover tests
+```

--- a/data/companies.csv
+++ b/data/companies.csv
@@ -1,0 +1,4 @@
+id,name,ticker
+1,Company A,CMPA
+2,Company B,CMPB
+3,Company C,CMPC

--- a/src/ticker.py
+++ b/src/ticker.py
@@ -1,0 +1,51 @@
+import csv
+from typing import List, Dict
+
+
+def load_companies(path: str) -> List[Dict[str, str]]:
+    """Load companies from a CSV file."""
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def save_companies(path: str, companies: List[Dict[str, str]]) -> None:
+    """Save companies to a CSV file."""
+    if not companies:
+        return
+    fieldnames = companies[0].keys()
+    with open(path, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(companies)
+
+
+def update_ticker(companies: List[Dict[str, str]], company_id: str, new_ticker: str) -> bool:
+    """Update ticker code for a company by ID.
+
+    Returns True if a company was updated."""
+    for company in companies:
+        if company['id'] == company_id:
+            company['ticker'] = new_ticker
+            return True
+    return False
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Update company ticker codes")
+    parser.add_argument('company_id', help='ID of company to update')
+    parser.add_argument('new_ticker', help='New ticker code')
+    parser.add_argument('--file', default='data/companies.csv', help='CSV file path')
+    args = parser.parse_args()
+
+    companies = load_companies(args.file)
+    if update_ticker(companies, args.company_id, args.new_ticker):
+        save_companies(args.file, companies)
+        print(f"Updated company {args.company_id} ticker to {args.new_ticker}")
+    else:
+        print(f"Company ID {args.company_id} not found")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1,0 +1,21 @@
+import unittest
+from src import ticker
+
+class TestTicker(unittest.TestCase):
+    def setUp(self):
+        self.companies = [
+            {'id': '1', 'name': 'Company A', 'ticker': 'CMPA'},
+            {'id': '2', 'name': 'Company B', 'ticker': 'CMPB'},
+        ]
+
+    def test_update_exists(self):
+        updated = ticker.update_ticker(self.companies, '1', 'NEW1')
+        self.assertTrue(updated)
+        self.assertEqual(self.companies[0]['ticker'], 'NEW1')
+
+    def test_update_missing(self):
+        updated = ticker.update_ticker(self.companies, '3', 'NEW3')
+        self.assertFalse(updated)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement ticker management CLI and helper functions
- update companies CSV dataset
- add unit tests
- update README with usage instructions

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_684a52f556b88326ad2a56c429fa538f